### PR TITLE
Fixed missing "Unable to resolve service for type 'Microsoft.Extensions.Logging.ILogger'" exception.

### DIFF
--- a/src/ODataAuthorization/ODataAuthorizationPolicies.cs
+++ b/src/ODataAuthorization/ODataAuthorizationPolicies.cs
@@ -146,7 +146,8 @@ namespace ODataAuthorization
             catch (Exception e)
             {
                 httpContext.RequestServices
-                    .GetRequiredService<ILogger>()
+                    .GetRequiredService<ILoggerFactory>()
+                    .CreateLogger("ODataAuthorizationPolicies")
                     .LogInformation(e, "Failed to parse SelectExpandClause");
             }
         }

--- a/src/ODataAuthorization/ODataAuthorizationPolicies.cs
+++ b/src/ODataAuthorization/ODataAuthorizationPolicies.cs
@@ -147,7 +147,7 @@ namespace ODataAuthorization
             {
                 httpContext.RequestServices
                     .GetRequiredService<ILoggerFactory>()
-                    .CreateLogger("ODataAuthorizationPolicies")
+                    .CreateLogger(nameof(ODataAuthorizationPolicies))
                     .LogInformation(e, "Failed to parse SelectExpandClause");
             }
         }


### PR DESCRIPTION
ASP.NET DI does not register a non-generic `ILogger` service, which results in a missing service exception. DI registers `ILogger<T>` or `ILoggerFactory`.

`ODataAuthorizationPolicies` is a static class, so it can't be used with `ILogger<T>`, so I pass the static class name to `ILoggerFactory.CreateLogger(categoryName)`.